### PR TITLE
Implement cribbage rules engine core systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -683,6 +683,26 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1047,6 +1067,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -1383,6 +1410,109 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1417,6 +1547,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1607,6 +1750,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1720,6 +1873,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -1778,6 +1941,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1793,6 +1975,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/color-convert": {
@@ -1819,6 +2014,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1958,6 +2160,19 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2018,6 +2233,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -2670,6 +2895,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2694,6 +2929,30 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
     },
     "node_modules/express": {
       "version": "4.21.2",
@@ -3091,6 +3350,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3126,6 +3395,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -3379,6 +3661,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3786,6 +4078,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -3913,6 +4218,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3984,6 +4296,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4007,12 +4336,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4040,6 +4389,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4107,6 +4463,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4142,6 +4511,26 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4182,6 +4571,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -4309,6 +4727,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -4478,6 +4912,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/phaser": {
       "version": "3.90.0",
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
@@ -4506,6 +4957,25 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -4570,6 +5040,34 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {
@@ -4654,6 +5152,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5140,6 +5645,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5265,6 +5777,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5273,6 +5792,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5454,6 +5980,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5465,6 +6004,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/supports-color": {
@@ -5499,6 +6051,33 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5600,6 +6179,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -5747,6 +6336,13 @@
         }
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -5867,6 +6463,29 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite-tsconfig-paths": {
@@ -6319,6 +6938,72 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6422,6 +7107,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -6582,7 +7284,8 @@
       "devDependencies": {
         "@types/node": "^20.12.7",
         "rimraf": "^5.0.5",
-        "typescript": "^5.4.3"
+        "typescript": "^5.4.3",
+        "vitest": "^1.4.0"
       }
     },
     "server": {

--- a/rules/package.json
+++ b/rules/package.json
@@ -6,10 +6,12 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
+    "vitest": "^1.4.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.4.3"
   }

--- a/rules/src/combos_pegging.ts
+++ b/rules/src/combos_pegging.ts
@@ -1,0 +1,78 @@
+import { ComboEvent, PeggingPileEntry } from './types';
+
+export function detectPeggingCombos(
+  pile: PeggingPileEntry[],
+  currentCount: number
+): ComboEvent[] {
+  if (pile.length === 0) {
+    return [];
+  }
+
+  const combos: ComboEvent[] = [];
+
+  if (currentCount === 15) {
+    combos.push({ kind: 'fifteen', damage: 3 });
+  }
+  if (currentCount === 31) {
+    combos.push({ kind: 'thirtyone', damage: 6 });
+  }
+
+  const pairCombo = detectPairCombo(pile);
+  if (pairCombo) {
+    combos.push(pairCombo);
+  }
+
+  const runCombo = detectRunCombo(pile);
+  if (runCombo) {
+    combos.push(runCombo);
+  }
+
+  return combos;
+}
+
+function detectPairCombo(pile: PeggingPileEntry[]): ComboEvent | null {
+  const last = pile[pile.length - 1];
+  const sameRank: PeggingPileEntry[] = [last];
+  for (let i = pile.length - 2; i >= 0; i -= 1) {
+    if (pile[i].card.rank === last.card.rank) {
+      sameRank.push(pile[i]);
+    } else {
+      break;
+    }
+  }
+
+  switch (sameRank.length) {
+    case 2:
+      return { kind: 'pair', damage: 2, length: 2 };
+    case 3:
+      return { kind: 'pair3', damage: 6, length: 3 };
+    case 4:
+      return { kind: 'pair4', damage: 12, length: 4 };
+    default:
+      return null;
+  }
+}
+
+function detectRunCombo(pile: PeggingPileEntry[]): ComboEvent | null {
+  const maxWindow = Math.min(7, pile.length);
+  for (let window = maxWindow; window >= 3; window -= 1) {
+    const slice = pile.slice(pile.length - window);
+    if (formsRun(slice)) {
+      return { kind: 'run', damage: window, length: window };
+    }
+  }
+  return null;
+}
+
+function formsRun(slice: PeggingPileEntry[]): boolean {
+  const ranks = slice.map((entry) => entry.card.rank).sort((a, b) => a - b);
+  for (let i = 1; i < ranks.length; i += 1) {
+    if (ranks[i] === ranks[i - 1]) {
+      return false;
+    }
+    if (ranks[i] !== ranks[i - 1] + 1) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rules/src/count.ts
+++ b/rules/src/count.ts
@@ -1,0 +1,27 @@
+import { Card } from './types';
+
+export class CountMeter {
+  private total = 0;
+
+  get value(): number {
+    return this.total;
+  }
+
+  canPlay(card: Card | number): boolean {
+    const value = typeof card === 'number' ? card : card.value;
+    return this.total + value <= 31;
+  }
+
+  add(card: Card | number): number {
+    const value = typeof card === 'number' ? card : card.value;
+    if (!this.canPlay(value)) {
+      throw new Error('Cannot exceed 31');
+    }
+    this.total += value;
+    return this.total;
+  }
+
+  reset(): void {
+    this.total = 0;
+  }
+}

--- a/rules/src/damage.ts
+++ b/rules/src/damage.ts
@@ -1,0 +1,40 @@
+import { ComboEvent, DamageEvent, DamageSource, HitPointTrack, PlayerId } from './types';
+
+export interface DamageContext {
+  source: DamageSource;
+  combo?: ComboEvent;
+  description?: string;
+  timestamp?: number;
+}
+
+export function applyDamage(
+  hp: HitPointTrack,
+  shield: HitPointTrack,
+  target: PlayerId,
+  amount: number,
+  context: DamageContext
+): DamageEvent {
+  const shieldBefore = shield[target];
+  const hpBefore = hp[target];
+  const absorbed = Math.min(shieldBefore, amount);
+  const remaining = amount - absorbed;
+  shield[target] = shieldBefore - absorbed;
+  hp[target] = Math.max(0, hpBefore - remaining);
+
+  const event: DamageEvent = {
+    target,
+    amount,
+    absorbed,
+    hpDamage: remaining,
+    shieldBefore,
+    hpBefore,
+    shieldAfter: shield[target],
+    hpAfter: hp[target],
+    source: context.source,
+    combo: context.combo,
+    description: context.description,
+    timestamp: context.timestamp ?? Date.now()
+  };
+
+  return event;
+}

--- a/rules/src/deck.ts
+++ b/rules/src/deck.ts
@@ -1,0 +1,45 @@
+import { Card, Suit } from './types';
+
+const SUITS: Suit[] = ['hearts', 'diamonds', 'clubs', 'spades'];
+const RANKS = Array.from({ length: 13 }, (_, index) => index + 1);
+
+function cardValue(rank: number): number {
+  return Math.min(rank, 10);
+}
+
+export function createStandardDeck(): Card[] {
+  return SUITS.flatMap((suit) =>
+    RANKS.map((rank) => ({
+      id: `${suit}-${rank}`,
+      rank,
+      suit,
+      value: cardValue(rank)
+    }))
+  );
+}
+
+type RandomFunction = () => number;
+
+function mulberry32(seed: number): RandomFunction {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface ShuffleOptions {
+  seed: number;
+}
+
+export function shuffleDeck({ seed }: ShuffleOptions): Card[] {
+  const rng = mulberry32(seed);
+  const deck = createStandardDeck();
+  for (let i = deck.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  return deck;
+}

--- a/rules/src/index.ts
+++ b/rules/src/index.ts
@@ -1,53 +1,19 @@
-export type Suit = 'hearts' | 'diamonds' | 'clubs' | 'spades';
-export type PlayerId = 'p1' | 'p2';
+import { createStandardDeck } from './deck';
+import { Card, GameState, HitPointTrack, PlayerHands } from './types';
 
-export interface Card {
-  id: string;
-  rank: number;
-  suit: Suit;
-  value: number;
-}
+export * from './types';
+export * from './deck';
+export * from './count';
+export * from './turn_manager';
+export * from './combos_pegging';
+export * from './score_resolution';
+export * from './damage';
 
-export interface PlayerHand {
-  p1: Card[];
-  p2: Card[];
-}
+export const DEFAULT_HP = 61;
 
-export interface HitPointTrack {
-  p1: number;
-  p2: number;
-}
-
-export interface GameState {
-  seed: number;
-  round: number;
-  dealer: PlayerId;
-  count: number;
-  pile: Card[];
-  turn: PlayerId;
-  hands: PlayerHand;
-  cribOwner: PlayerId;
-  crib: Card[];
-  starter: Card | null;
-  hp: HitPointTrack;
-  shield: HitPointTrack;
-  phase: 'deal' | 'discard' | 'cut' | 'pegging' | 'resolution' | 'results';
-}
-
-const DEFAULT_HP = 61;
-
-export const STANDARD_DECK: ReadonlyArray<Card> = (() => {
-  const suits: Suit[] = ['hearts', 'diamonds', 'clubs', 'spades'];
-  const ranks = Array.from({ length: 13 }, (_, index) => index + 1);
-  return suits.flatMap((suit) =>
-    ranks.map((rank) => ({
-      id: `${suit}-${rank}`,
-      rank,
-      suit,
-      value: Math.min(rank, 10)
-    }))
-  );
-})();
+export const STANDARD_DECK: ReadonlyArray<Card> = Object.freeze(
+  createStandardDeck()
+);
 
 export function createInitialState(seed = Date.now()): GameState {
   return {
@@ -57,16 +23,24 @@ export function createInitialState(seed = Date.now()): GameState {
     count: 0,
     pile: [],
     turn: 'p1',
-    hands: { p1: [], p2: [] },
+    hands: emptyHands(),
     cribOwner: 'p1',
     crib: [],
     starter: null,
-    hp: { p1: DEFAULT_HP, p2: DEFAULT_HP },
+    hp: defaultHpTrack(),
     shield: { p1: 0, p2: 0 },
     phase: 'deal'
   };
 }
 
+function emptyHands(): PlayerHands {
+  return { p1: [], p2: [] };
+}
+
+function defaultHpTrack(): HitPointTrack {
+  return { p1: DEFAULT_HP, p2: DEFAULT_HP };
+}
+
 export function getCardValue(card: Card): number {
-  return Math.min(card.rank, 10);
+  return card.value;
 }

--- a/rules/src/score_resolution.ts
+++ b/rules/src/score_resolution.ts
@@ -1,0 +1,178 @@
+import { Card, ResolutionDetail, ResolutionResult } from './types';
+
+export interface ScoreOptions {
+  hand: Card[];
+  starter: Card;
+  isCrib?: boolean;
+}
+
+export function scoreHand(options: ScoreOptions): ResolutionResult {
+  const { hand, starter, isCrib = false } = options;
+  const allCards = [...hand, starter];
+  const details: ResolutionDetail[] = [];
+
+  const fifteenDamage = scoreFifteens(allCards, details);
+  const pairDamage = scorePairs(allCards, details);
+  const runDamage = scoreRuns(allCards, details);
+  const flushShield = scoreFlush(hand, starter, isCrib, details);
+  const initiative = scoreNobs(hand, starter, details);
+
+  return {
+    damage: fifteenDamage + pairDamage + runDamage,
+    shield: flushShield,
+    initiative,
+    details
+  };
+}
+
+function scoreFifteens(cards: Card[], details: ResolutionDetail[]): number {
+  const combos = enumerateSubsets(cards);
+  let damage = 0;
+  for (const subset of combos) {
+    const total = subset.reduce((sum, card) => sum + card.value, 0);
+    if (total === 15) {
+      damage += 2;
+      details.push({ kind: 'fifteen', points: 2, cards: subset.slice() });
+    }
+  }
+  return damage;
+}
+
+function scorePairs(cards: Card[], details: ResolutionDetail[]): number {
+  const byRank = new Map<number, Card[]>();
+  for (const card of cards) {
+    const group = byRank.get(card.rank) ?? [];
+    group.push(card);
+    byRank.set(card.rank, group);
+  }
+  let damage = 0;
+  for (const group of byRank.values()) {
+    if (group.length >= 2) {
+      const pairCount = (group.length * (group.length - 1)) / 2;
+      const points = pairCount * 2;
+      damage += points;
+      const kind =
+        group.length === 2 ? 'pair' : group.length === 3 ? 'pair3' : 'pair4';
+      details.push({ kind, points, cards: group.slice() });
+    }
+  }
+  return damage;
+}
+
+function scoreRuns(cards: Card[], details: ResolutionDetail[]): number {
+  const groups = new Map<number, Card[]>();
+  for (const card of cards) {
+    const existing = groups.get(card.rank) ?? [];
+    existing.push(card);
+    groups.set(card.rank, existing);
+  }
+  const ranks = Array.from(groups.keys()).sort((a, b) => a - b);
+  let damage = 0;
+  let currentRun: number[] = [];
+
+  const flushRun = () => {
+    if (currentRun.length >= 3) {
+      const combos = buildRunCombos(groups, currentRun);
+      for (const combo of combos) {
+        damage += currentRun.length;
+        details.push({ kind: 'run', points: currentRun.length, cards: combo, length: currentRun.length });
+      }
+    }
+    currentRun = [];
+  };
+
+  for (const rank of ranks) {
+    if (currentRun.length === 0) {
+      currentRun.push(rank);
+      continue;
+    }
+    const prev = currentRun[currentRun.length - 1];
+    if (rank === prev + 1) {
+      currentRun.push(rank);
+    } else {
+      flushRun();
+      currentRun.push(rank);
+    }
+  }
+  flushRun();
+
+  return damage;
+}
+
+function buildRunCombos(groups: Map<number, Card[]>, ranks: number[]): Card[][] {
+  const combos: Card[][] = [];
+  const current: Card[] = [];
+
+  const backtrack = (index: number) => {
+    if (index === ranks.length) {
+      combos.push(current.slice());
+      return;
+    }
+    const rank = ranks[index];
+    const cards = groups.get(rank) ?? [];
+    for (const card of cards) {
+      current.push(card);
+      backtrack(index + 1);
+      current.pop();
+    }
+  };
+
+  backtrack(0);
+  return combos;
+}
+
+function scoreFlush(
+  hand: Card[],
+  starter: Card,
+  isCrib: boolean,
+  details: ResolutionDetail[]
+): number {
+  if (hand.length === 0) {
+    return 0;
+  }
+  const firstSuit = hand[0].suit;
+  const allMatchHand = hand.every((card) => card.suit === firstSuit);
+  if (!allMatchHand) {
+    return 0;
+  }
+  const starterMatches = starter.suit === firstSuit;
+  if (isCrib && !starterMatches) {
+    return 0;
+  }
+  const shield = starterMatches ? 5 : 4;
+  if (isCrib && shield !== 5) {
+    return 0;
+  }
+  const cards = [...hand, starterMatches ? starter : undefined].filter(
+    (card): card is Card => Boolean(card)
+  );
+  details.push({ kind: 'flush', points: shield, cards });
+  return shield;
+}
+
+function scoreNobs(hand: Card[], starter: Card, details: ResolutionDetail[]): boolean {
+  if (!starter) {
+    return false;
+  }
+  const jack = hand.find((card) => card.rank === 11 && card.suit === starter.suit);
+  if (jack) {
+    details.push({ kind: 'nobs', points: 0, cards: [jack, starter] });
+    return true;
+  }
+  return false;
+}
+
+function enumerateSubsets(cards: Card[]): Card[][] {
+  const subsets: Card[][] = [];
+  const total = 1 << cards.length;
+  for (let mask = 1; mask < total; mask += 1) {
+    const subset: Card[] = [];
+    for (let i = 0; i < cards.length; i += 1) {
+      if (mask & (1 << i)) {
+        subset.push(cards[i]);
+      }
+    }
+    subsets.push(subset);
+  }
+  return subsets;
+}

--- a/rules/src/turn_manager.ts
+++ b/rules/src/turn_manager.ts
@@ -1,0 +1,103 @@
+import { Card, GoResolution, PeggingPileEntry, PlayerId } from './types';
+import { CountMeter } from './count';
+
+export interface PlayCardResult {
+  count: number;
+  pile: PeggingPileEntry[];
+  resetRequired: boolean;
+}
+
+export class PeggingTurnManager {
+  private readonly countMeter = new CountMeter();
+  private readonly pile: PeggingPileEntry[] = [];
+  private readonly passed: Record<PlayerId, boolean> = { p1: false, p2: false };
+  private lastPlayerToPlay: PlayerId | null = null;
+
+  constructor(private currentTurn: PlayerId) {}
+
+  get turn(): PlayerId {
+    return this.currentTurn;
+  }
+
+  get count(): number {
+    return this.countMeter.value;
+  }
+
+  get orderedPile(): PeggingPileEntry[] {
+    return [...this.pile];
+  }
+
+  private otherPlayer(player: PlayerId): PlayerId {
+    return player === 'p1' ? 'p2' : 'p1';
+  }
+
+  canPlayCard(card: Card): boolean {
+    return this.countMeter.canPlay(card);
+  }
+
+  canPlayerPlay(hand: Card[]): boolean {
+    return hand.some((card) => this.canPlayCard(card));
+  }
+
+  playCard(player: PlayerId, card: Card): PlayCardResult {
+    if (player !== this.currentTurn) {
+      throw new Error('Not this player\'s turn');
+    }
+    if (!this.countMeter.canPlay(card)) {
+      throw new Error('Play exceeds 31');
+    }
+    const count = this.countMeter.add(card);
+    this.pile.push({ card, player });
+    this.lastPlayerToPlay = player;
+    this.passed.p1 = false;
+    this.passed.p2 = false;
+    const resetRequired = count === 31;
+    this.currentTurn = this.otherPlayer(player);
+    return {
+      count,
+      pile: this.orderedPile,
+      resetRequired
+    };
+  }
+
+  declareGo(player: PlayerId, hand: Card[]): GoResolution {
+    if (player !== this.currentTurn) {
+      throw new Error('Not this player\'s turn');
+    }
+    if (this.canPlayerPlay(hand)) {
+      throw new Error('Player has a legal play and cannot call go');
+    }
+    this.passed[player] = true;
+    const opponent = this.otherPlayer(player);
+    this.currentTurn = opponent;
+    if (this.passed[opponent]) {
+      const awardedTo = this.lastPlayerToPlay ?? opponent;
+      this.resetVolley(awardedTo);
+      return { awardedTo };
+    }
+    return {};
+  }
+
+  resetAfterThirtyOne(): void {
+    if (!this.lastPlayerToPlay) {
+      return;
+    }
+    const next = this.otherPlayer(this.lastPlayerToPlay);
+    this.resetCounts();
+    this.currentTurn = next;
+  }
+
+  resetVolley(lastScoringPlayer: PlayerId): void {
+    const next = this.otherPlayer(lastScoringPlayer);
+    this.resetCounts();
+    this.currentTurn = next;
+  }
+
+  private resetCounts(): void {
+    this.countMeter.reset();
+    this.pile.splice(0, this.pile.length);
+    this.passed.p1 = false;
+    this.passed.p2 = false;
+    this.lastPlayerToPlay = null;
+  }
+}

--- a/rules/src/types.ts
+++ b/rules/src/types.ts
@@ -1,0 +1,102 @@
+export type Suit = 'hearts' | 'diamonds' | 'clubs' | 'spades';
+export type PlayerId = 'p1' | 'p2';
+export type GamePhase =
+  | 'deal'
+  | 'discard'
+  | 'cut'
+  | 'pegging'
+  | 'resolution'
+  | 'results';
+
+export interface Card {
+  id: string;
+  rank: number;
+  suit: Suit;
+  value: number;
+}
+
+export interface PlayerHands {
+  p1: Card[];
+  p2: Card[];
+}
+
+export interface HitPointTrack {
+  p1: number;
+  p2: number;
+}
+
+export interface GameState {
+  seed: number;
+  round: number;
+  dealer: PlayerId;
+  count: number;
+  pile: Card[];
+  turn: PlayerId;
+  hands: PlayerHands;
+  cribOwner: PlayerId;
+  crib: Card[];
+  starter: Card | null;
+  hp: HitPointTrack;
+  shield: HitPointTrack;
+  phase: GamePhase;
+}
+
+export interface PlayIntent {
+  roomId: string;
+  player: PlayerId;
+  cardId: string;
+}
+
+export type ComboKind =
+  | 'fifteen'
+  | 'thirtyone'
+  | 'pair'
+  | 'pair3'
+  | 'pair4'
+  | 'run';
+
+export interface ComboEvent {
+  kind: ComboKind;
+  damage: number;
+  length?: number;
+}
+
+export type DamageSource = 'pegging' | 'resolution' | 'ability' | 'status';
+
+export interface DamageEvent {
+  target: PlayerId;
+  amount: number;
+  absorbed: number;
+  hpDamage: number;
+  shieldBefore: number;
+  hpBefore: number;
+  shieldAfter: number;
+  hpAfter: number;
+  source: DamageSource;
+  combo?: ComboEvent;
+  description?: string;
+  timestamp: number;
+}
+
+export interface ResolutionDetail {
+  kind: 'fifteen' | 'pair' | 'pair3' | 'pair4' | 'run' | 'flush' | 'nobs';
+  points: number;
+  cards: Card[];
+  length?: number;
+}
+
+export interface ResolutionResult {
+  damage: number;
+  shield: number;
+  initiative: boolean;
+  details: ResolutionDetail[];
+}
+
+export interface PeggingPileEntry {
+  card: Card;
+  player: PlayerId;
+}
+
+export interface GoResolution {
+  awardedTo?: PlayerId;
+}

--- a/rules/tests/combos_pegging.test.ts
+++ b/rules/tests/combos_pegging.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectPeggingCombos } from '../src';
+import { makeCard, pileEntry } from './helpers';
+
+describe('detectPeggingCombos', () => {
+  it('detects a fifteen combo', () => {
+    const pile = [pileEntry(makeCard(5)), pileEntry(makeCard(10, 'clubs'), 'p2')];
+    const combos = detectPeggingCombos(pile, 15);
+    expect(combos).toEqual([{ kind: 'fifteen', damage: 3 }]);
+  });
+
+  it('detects thirty-one', () => {
+    const pile = [
+      pileEntry(makeCard(10)),
+      pileEntry(makeCard(5, 'clubs'), 'p2'),
+      pileEntry(makeCard(6, 'diamonds')),
+      pileEntry(makeCard(10, 'spades'), 'p2')
+    ];
+    const combos = detectPeggingCombos(pile, 31);
+    expect(combos).toContainEqual({ kind: 'thirtyone', damage: 6 });
+  });
+
+  it('detects contiguous pairs, trips, and quads', () => {
+    const base = [pileEntry(makeCard(7)), pileEntry(makeCard(7, 'clubs'), 'p2')];
+    expect(detectPeggingCombos(base, 14)).toContainEqual({
+      kind: 'pair',
+      damage: 2,
+      length: 2
+    });
+
+    const trips = [...base, pileEntry(makeCard(7, 'diamonds'))];
+    expect(detectPeggingCombos(trips, 21)).toContainEqual({
+      kind: 'pair3',
+      damage: 6,
+      length: 3
+    });
+
+    const quads = [...trips, pileEntry(makeCard(7, 'spades'), 'p2')];
+    expect(detectPeggingCombos(quads, 28)).toContainEqual({
+      kind: 'pair4',
+      damage: 12,
+      length: 4
+    });
+  });
+
+  it('requires pairs to be contiguous', () => {
+    const pile = [
+      pileEntry(makeCard(7)),
+      pileEntry(makeCard(5, 'clubs'), 'p2'),
+      pileEntry(makeCard(7, 'diamonds'))
+    ];
+    const combos = detectPeggingCombos(pile, 19);
+    expect(combos.find((combo) => combo.kind.startsWith('pair'))).toBeUndefined();
+  });
+
+  it('detects the longest run only', () => {
+    const pile = [
+      pileEntry(makeCard(2)),
+      pileEntry(makeCard(3, 'clubs'), 'p2'),
+      pileEntry(makeCard(4, 'diamonds')),
+      pileEntry(makeCard(5, 'spades'), 'p2')
+    ];
+    const combos = detectPeggingCombos(pile, 14);
+    expect(combos).toContainEqual({ kind: 'run', damage: 4, length: 4 });
+    expect(combos.filter((combo) => combo.kind === 'run')).toHaveLength(1);
+  });
+
+  it('can report simultaneous fifteen and run combos', () => {
+    const pile = [
+      pileEntry(makeCard(4)),
+      pileEntry(makeCard(6, 'clubs'), 'p2'),
+      pileEntry(makeCard(5, 'diamonds'))
+    ];
+    const combos = detectPeggingCombos(pile, 15);
+    expect(combos).toContainEqual({ kind: 'fifteen', damage: 3 });
+    expect(combos).toContainEqual({ kind: 'run', damage: 3, length: 3 });
+  });
+});

--- a/rules/tests/count_turn_manager.test.ts
+++ b/rules/tests/count_turn_manager.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { CountMeter, PeggingTurnManager } from '../src';
+import { makeCard } from './helpers';
+
+describe('CountMeter', () => {
+  it('prevents plays that exceed 31', () => {
+    const meter = new CountMeter();
+    meter.add(makeCard(10));
+    meter.add(makeCard(10));
+    expect(() => meter.add(12)).toThrowError('Cannot exceed 31');
+  });
+});
+
+describe('PeggingTurnManager', () => {
+  it('resets after reaching 31', () => {
+    const manager = new PeggingTurnManager('p1');
+    manager.playCard('p1', makeCard(10));
+    manager.playCard('p2', makeCard(5, 'clubs'));
+    manager.playCard('p1', makeCard(6, 'diamonds'));
+    manager.playCard('p2', makeCard(5, 'spades'));
+    const result = manager.playCard('p1', makeCard(5, 'hearts'));
+    expect(result.count).toBe(31);
+    expect(result.resetRequired).toBe(true);
+    manager.resetAfterThirtyOne();
+    expect(manager.count).toBe(0);
+    expect(manager.orderedPile).toHaveLength(0);
+    expect(manager.turn).toBe('p2');
+  });
+
+  it('awards go to the last player able to act and resets the volley', () => {
+    const manager = new PeggingTurnManager('p1');
+    manager.playCard('p1', makeCard(4));
+    manager.playCard('p2', makeCard(5, 'clubs'));
+    manager.playCard('p1', makeCard(10, 'diamonds'));
+    manager.playCard('p2', makeCard(9, 'spades'));
+
+    const goResult = manager.declareGo('p1', [makeCard(4, 'diamonds')]);
+    expect(goResult.awardedTo).toBeUndefined();
+    expect(manager.turn).toBe('p2');
+    expect(manager.count).toBe(28);
+
+    const secondGo = manager.declareGo('p2', [makeCard(4, 'spades')]);
+    expect(secondGo.awardedTo).toBe('p2');
+    expect(manager.count).toBe(0);
+    expect(manager.orderedPile).toHaveLength(0);
+    expect(manager.turn).toBe('p1');
+  });
+
+  it('prevents players from calling go when they have a legal play', () => {
+    const manager = new PeggingTurnManager('p1');
+    manager.playCard('p1', makeCard(10));
+    expect(() => manager.declareGo('p2', [makeCard(5)])).toThrow(
+      'Player has a legal play and cannot call go'
+    );
+  });
+});

--- a/rules/tests/damage.test.ts
+++ b/rules/tests/damage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyDamage, ComboEvent, HitPointTrack } from '../src';
+
+describe('applyDamage', () => {
+  it('applies shield before HP and logs the event', () => {
+    const hp: HitPointTrack = { p1: 61, p2: 61 };
+    const shield: HitPointTrack = { p1: 5, p2: 0 };
+    const combo: ComboEvent = { kind: 'fifteen', damage: 3 };
+    const event = applyDamage(hp, shield, 'p1', 7, {
+      source: 'pegging',
+      combo,
+      description: 'Fifteen damage'
+    });
+    expect(event.absorbed).toBe(5);
+    expect(event.hpDamage).toBe(2);
+    expect(event.hpAfter).toBe(59);
+    expect(event.shieldAfter).toBe(0);
+    expect(event.combo).toEqual(combo);
+    expect(event.description).toBe('Fifteen damage');
+    expect(event.timestamp).toBeTypeOf('number');
+  });
+});

--- a/rules/tests/helpers.ts
+++ b/rules/tests/helpers.ts
@@ -1,0 +1,19 @@
+import { Card, PeggingPileEntry, PlayerId, Suit } from '../src';
+
+let idCounter = 0;
+
+export function makeCard(rank: number, suit: Suit = 'hearts'): Card {
+  return {
+    id: `${suit}-${rank}-${idCounter++}`,
+    rank,
+    suit,
+    value: Math.min(rank, 10)
+  };
+}
+
+export function pileEntry(
+  card: Card,
+  player: PlayerId = 'p1'
+): PeggingPileEntry {
+  return { card, player };
+}

--- a/rules/tests/score_resolution.test.ts
+++ b/rules/tests/score_resolution.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { scoreHand } from '../src';
+import { makeCard } from './helpers';
+
+describe('scoreHand', () => {
+  it('matches golden vector for four fives and a jack starter', () => {
+    const hand = [
+      makeCard(5, 'hearts'),
+      makeCard(5, 'clubs'),
+      makeCard(5, 'diamonds'),
+      makeCard(11, 'spades')
+    ];
+    const starter = makeCard(5, 'spades');
+    const result = scoreHand({ hand, starter });
+    expect(result.damage).toBe(28);
+    expect(result.shield).toBe(0);
+    expect(result.initiative).toBe(true);
+    expect(result.details.filter((detail) => detail.kind === 'fifteen')).toHaveLength(8);
+    const quad = result.details.find((detail) => detail.kind === 'pair4');
+    expect(quad?.points).toBe(12);
+    expect(result.details.some((detail) => detail.kind === 'nobs')).toBe(true);
+  });
+
+  it('scores flush shields for hands and cribs correctly', () => {
+    const handFlush = [
+      makeCard(2, 'clubs'),
+      makeCard(4, 'clubs'),
+      makeCard(7, 'clubs'),
+      makeCard(9, 'clubs')
+    ];
+    const starterOffSuit = makeCard(12, 'diamonds');
+    const starterMatching = makeCard(8, 'clubs');
+
+    const handResult = scoreHand({ hand: handFlush, starter: starterOffSuit });
+    expect(handResult.shield).toBe(4);
+
+    const cribResult = scoreHand({
+      hand: handFlush,
+      starter: starterMatching,
+      isCrib: true
+    });
+    expect(cribResult.shield).toBe(5);
+
+    const noCribFlush = scoreHand({
+      hand: handFlush,
+      starter: starterOffSuit,
+      isCrib: true
+    });
+    expect(noCribFlush.shield).toBe(0);
+  });
+
+  it('tallies runs, pairs, and fifteens together', () => {
+    const hand = [
+      makeCard(3, 'hearts'),
+      makeCard(4, 'clubs'),
+      makeCard(5, 'diamonds'),
+      makeCard(5, 'spades')
+    ];
+    const starter = makeCard(6, 'hearts');
+    const result = scoreHand({ hand, starter });
+    expect(result.damage).toBe(14);
+    const runDetails = result.details.filter((detail) => detail.kind === 'run');
+    expect(runDetails).toHaveLength(2);
+    expect(runDetails[0]?.length).toBe(4);
+    expect(result.details.filter((detail) => detail.kind === 'fifteen')).toHaveLength(2);
+    expect(result.details.filter((detail) => detail.kind === 'pair')).toHaveLength(1);
+  });
+
+  it('recognises nobs when the jack matches the starter suit', () => {
+    const hand = [
+      makeCard(11, 'hearts'),
+      makeCard(2, 'clubs'),
+      makeCard(7, 'diamonds'),
+      makeCard(9, 'spades')
+    ];
+    const starter = makeCard(5, 'hearts');
+    const result = scoreHand({ hand, starter });
+    expect(result.initiative).toBe(true);
+    expect(result.details.some((detail) => detail.kind === 'nobs')).toBe(true);
+  });
+});

--- a/rules/vitest.config.ts
+++ b/rules/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- add shared TypeScript models for cards, game state, combos, and damage logs per PRD schemas
- implement seeded deck generation, count/turn management, pegging combo detection, resolution scoring, and shield-aware damage helpers
- configure vitest and add comprehensive unit specs covering pegging golden vectors, resolution edge cases, and damage handling

## Testing
- npm run build --workspace=rules
- npm run test --workspace=rules

------
https://chatgpt.com/codex/tasks/task_e_68cf4caca768832a844cae5cc791d105