### PR TITLE
Implement game state lifecycle and resolution logic

### DIFF
--- a/rules/src/constants.ts
+++ b/rules/src/constants.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_HP = 61;
+export const STANDARD_HAND_SIZE = 6;
+export const CRIB_DISCARD_COUNT = 2;
+export const GO_BONUS_DAMAGE = 1;

--- a/rules/src/game_state.ts
+++ b/rules/src/game_state.ts
@@ -1,0 +1,380 @@
+import {
+  Card,
+  ComboEvent,
+  ComboLogEntry,
+  DamageEvent,
+  GamePhase,
+  GameState,
+  GoResolution,
+  PeggingPileEntry,
+  PeggingTracker,
+  PlayerHands,
+  PlayerId,
+  PlayCardOutcome,
+  ResolutionResult,
+  ResolutionSummary
+} from './types';
+import { shuffleDeck } from './deck';
+import { detectPeggingCombos } from './combos_pegging';
+import { applyDamage } from './damage';
+import { scoreHand } from './score_resolution';
+import {
+  CRIB_DISCARD_COUNT,
+  DEFAULT_HP,
+  GO_BONUS_DAMAGE,
+  STANDARD_HAND_SIZE
+} from './constants';
+
+export interface CreateGameStateOptions {
+  seed?: number;
+  dealer?: PlayerId;
+  hpTotal?: number;
+  deck?: Card[];
+}
+
+export function createGameState(options: CreateGameStateOptions = {}): GameState {
+  const seed = options.seed ?? Date.now();
+  const dealer = options.dealer ?? 'p1';
+  const hpTotal = options.hpTotal ?? DEFAULT_HP;
+  const startingDeck = options.deck ? cloneCards(options.deck) : shuffleDeck({ seed });
+  const { hands, remaining } = dealHands(startingDeck);
+
+  const state: GameState = {
+    seed,
+    round: 1,
+    dealer,
+    count: 0,
+    pile: [],
+    turn: otherPlayer(dealer),
+    hands,
+    cribOwner: dealer,
+    crib: [],
+    starter: null,
+    deck: remaining,
+    hp: { p1: hpTotal, p2: hpTotal },
+    shield: { p1: 0, p2: 0 },
+    damageLog: [],
+    comboLog: [],
+    initiative: null,
+    pegging: createPeggingTracker(),
+    phase: 'discard'
+  };
+
+  return state;
+}
+
+export function discardToCrib(state: GameState, player: PlayerId, cardIds: string[]): void {
+  ensurePhase(state, 'discard');
+  if (cardIds.length === 0) {
+    throw new Error('Must discard at least one card');
+  }
+  const hand = state.hands[player];
+  if (hand.length - cardIds.length < STANDARD_HAND_SIZE - CRIB_DISCARD_COUNT) {
+    throw new Error('Cannot discard more than allowed');
+  }
+
+  for (const cardId of cardIds) {
+    const card = removeFromHand(hand, cardId);
+    state.crib.push(card);
+  }
+
+  if (state.hands.p1.length === STANDARD_HAND_SIZE - CRIB_DISCARD_COUNT &&
+      state.hands.p2.length === STANDARD_HAND_SIZE - CRIB_DISCARD_COUNT) {
+    state.phase = 'cut';
+  }
+}
+
+export function cutStarter(state: GameState): Card {
+  ensurePhase(state, 'cut');
+  if (state.deck.length === 0) {
+    throw new Error('Deck is empty');
+  }
+  const starter = state.deck.shift()!;
+  state.starter = starter;
+  state.phase = 'pegging';
+  state.count = 0;
+  state.pile = [];
+  state.pegging = createPeggingTracker();
+  return starter;
+}
+
+export function playCard(state: GameState, player: PlayerId, cardId: string): PlayCardOutcome {
+  ensurePhase(state, 'pegging');
+  if (state.turn !== player) {
+    throw new Error('Not this player\'s turn');
+  }
+  const hand = state.hands[player];
+  const index = hand.findIndex((item) => item.id === cardId);
+  if (index === -1) {
+    throw new Error('Card not found in hand');
+  }
+  const card = hand[index];
+  if (state.count + card.value > 31) {
+    throw new Error('Play exceeds 31');
+  }
+  hand.splice(index, 1);
+
+  state.count += card.value;
+  const entry: PeggingPileEntry = { card, player };
+  state.pile.push(entry);
+  state.pegging.lastPlayedBy = player;
+  state.pegging.passed.p1 = false;
+  state.pegging.passed.p2 = false;
+
+  const combos = detectPeggingCombos(state.pile, state.count);
+  const damageEvent = applyComboDamage(state, otherPlayer(player), combos);
+  logPeggingCombos(state, player, combos);
+  const newCount = state.count;
+
+  let reset = false;
+  if (newCount === 31) {
+    reset = true;
+    resetPegging(state);
+    setNextTurnAfterReset(state, otherPlayer(player));
+  } else {
+    state.turn = otherPlayer(player);
+  }
+
+  maybeAdvanceToResolution(state);
+
+  return {
+    player,
+    card,
+    count: newCount,
+    combos,
+    damageEvent,
+    reset
+  };
+}
+
+export function declareGo(state: GameState, player: PlayerId): GoResolution {
+  ensurePhase(state, 'pegging');
+  if (state.turn !== player) {
+    throw new Error('Not this player\'s turn');
+  }
+  if (hasLegalPlay(state.hands[player], state.count)) {
+    throw new Error('Player has a legal play');
+  }
+
+  state.pegging.passed[player] = true;
+  const opponent = otherPlayer(player);
+  state.turn = opponent;
+
+  if (state.pegging.passed[opponent]) {
+    const awardedTo = state.pegging.lastPlayedBy ?? opponent;
+    const damageEvent = awardGoBonus(state, awardedTo);
+    resetPegging(state);
+    setNextTurnAfterReset(state, otherPlayer(awardedTo));
+    maybeAdvanceToResolution(state);
+    return { awardedTo, damageEvent, reset: true };
+  }
+
+  return { reset: false };
+}
+
+export function resolveRound(state: GameState): ResolutionSummary {
+  ensurePhase(state, 'resolution');
+  if (!state.starter) {
+    throw new Error('Starter has not been cut');
+  }
+
+  const handResults: Record<PlayerId, ResolutionResult> = {
+    p1: emptyResolutionResult(),
+    p2: emptyResolutionResult()
+  };
+  const damageEvents: DamageEvent[] = [];
+  const order: PlayerId[] = state.dealer === 'p1' ? ['p2', 'p1'] : ['p1', 'p2'];
+
+  for (const seat of order) {
+    const result = scoreHand({ hand: state.hands[seat], starter: state.starter });
+    handResults[seat] = result;
+    if (result.damage > 0) {
+      const damageEvent = applyDamage(state.hp, state.shield, otherPlayer(seat), result.damage, {
+        source: 'resolution',
+        description: `Resolution damage for ${seat}`
+      });
+      damageEvents.push(damageEvent);
+      state.damageLog.push(damageEvent);
+    }
+    if (result.shield > 0) {
+      state.shield[seat] += result.shield;
+    }
+    if (result.initiative) {
+      state.initiative = seat;
+    }
+  }
+
+  let cribResult: ResolutionResult | null = null;
+  if (state.crib.length > 0) {
+    const result = scoreHand({ hand: state.crib, starter: state.starter, isCrib: true });
+    cribResult = result;
+    if (result.damage > 0) {
+      const damageEvent = applyDamage(state.hp, state.shield, otherPlayer(state.cribOwner), result.damage, {
+        source: 'resolution',
+        description: 'Crib damage'
+      });
+      damageEvents.push(damageEvent);
+      state.damageLog.push(damageEvent);
+    }
+    if (result.shield > 0) {
+      state.shield[state.cribOwner] += result.shield;
+    }
+    if (result.initiative) {
+      state.initiative = state.cribOwner;
+    }
+  }
+
+  if (state.hp.p1 === 0 || state.hp.p2 === 0) {
+    state.phase = 'results';
+    return { handResults, cribResult, damageEvents };
+  }
+
+  startNextRound(state);
+  return { handResults, cribResult, damageEvents };
+}
+
+export function startNextRound(state: GameState): void {
+  state.round += 1;
+  state.dealer = otherPlayer(state.dealer);
+  state.cribOwner = state.dealer;
+  state.phase = 'deal';
+
+  const seed = state.seed + state.round - 1;
+  const deck = shuffleDeck({ seed });
+  const { hands, remaining } = dealHands(deck);
+
+  state.hands = hands;
+  state.deck = remaining;
+  state.crib = [];
+  state.starter = null;
+  state.count = 0;
+  state.pile = [];
+  state.pegging = createPeggingTracker();
+  state.phase = 'discard';
+
+  const lead = state.initiative ?? otherPlayer(state.dealer);
+  state.turn = lead;
+  state.initiative = null;
+}
+
+function otherPlayer(player: PlayerId): PlayerId {
+  return player === 'p1' ? 'p2' : 'p1';
+}
+
+function dealHands(deck: Card[]): { hands: PlayerHands; remaining: Card[] } {
+  const p1 = deck.slice(0, STANDARD_HAND_SIZE);
+  const p2 = deck.slice(STANDARD_HAND_SIZE, STANDARD_HAND_SIZE * 2);
+  const remaining = deck.slice(STANDARD_HAND_SIZE * 2);
+  return {
+    hands: { p1, p2 },
+    remaining
+  };
+}
+
+function createPeggingTracker(): PeggingTracker {
+  return {
+    passed: { p1: false, p2: false },
+    lastPlayedBy: null
+  };
+}
+
+function ensurePhase(state: GameState, phase: GamePhase): void {
+  if (state.phase !== phase) {
+    throw new Error(`Expected phase ${phase} but was ${state.phase}`);
+  }
+}
+
+function removeFromHand(hand: Card[], cardId: string): Card {
+  const index = hand.findIndex((card) => card.id === cardId);
+  if (index === -1) {
+    throw new Error('Card not found in hand');
+  }
+  return hand.splice(index, 1)[0];
+}
+
+function hasLegalPlay(hand: Card[], count: number): boolean {
+  return hand.some((card) => card.value + count <= 31);
+}
+
+function applyComboDamage(state: GameState, target: PlayerId, combos: ComboEvent[]): DamageEvent | undefined {
+  const total = combos.reduce((sum, combo) => sum + combo.damage, 0);
+  if (total <= 0) {
+    return undefined;
+  }
+  const description = describeCombos(combos);
+  const damageEvent = applyDamage(state.hp, state.shield, target, total, {
+    source: 'pegging',
+    description
+  });
+  state.damageLog.push(damageEvent);
+  return damageEvent;
+}
+
+function describeCombos(combos: ComboEvent[]): string {
+  return combos
+    .map((combo) =>
+      combo.length ? `${combo.kind}(${combo.length})` : combo.kind
+    )
+    .join(', ');
+}
+
+function logPeggingCombos(state: GameState, player: PlayerId, combos: ComboEvent[]): void {
+  if (combos.length === 0) {
+    return;
+  }
+  const entry: ComboLogEntry = {
+    player,
+    combos: combos.map((combo) => ({ ...combo })),
+    count: state.count,
+    pile: state.pile.map((item) => ({ card: { ...item.card }, player: item.player })),
+    round: state.round,
+    phase: state.phase,
+    timestamp: Date.now()
+  };
+  state.comboLog.push(entry);
+}
+
+function resetPegging(state: GameState): void {
+  state.count = 0;
+  state.pile = [];
+  state.pegging = createPeggingTracker();
+}
+
+function setNextTurnAfterReset(state: GameState, preferred: PlayerId): void {
+  const opponent = otherPlayer(preferred);
+  if (state.hands[preferred].length > 0) {
+    state.turn = preferred;
+  } else if (state.hands[opponent].length > 0) {
+    state.turn = opponent;
+  } else {
+    state.turn = preferred;
+  }
+}
+
+function maybeAdvanceToResolution(state: GameState): void {
+  if (state.hands.p1.length === 0 && state.hands.p2.length === 0 && state.count === 0) {
+    state.phase = 'resolution';
+    state.turn = state.dealer;
+  }
+}
+
+function awardGoBonus(state: GameState, awardedTo: PlayerId): DamageEvent | undefined {
+  if (GO_BONUS_DAMAGE <= 0) {
+    return undefined;
+  }
+  const target = otherPlayer(awardedTo);
+  const damageEvent = applyDamage(state.hp, state.shield, target, GO_BONUS_DAMAGE, {
+    source: 'pegging',
+    description: 'Go bonus'
+  });
+  state.damageLog.push(damageEvent);
+  return damageEvent;
+}
+
+function emptyResolutionResult(): ResolutionResult {
+  return { damage: 0, shield: 0, initiative: false, details: [] };
+}
+
+function cloneCards(cards: Card[]): Card[] {
+  return cards.map((card) => ({ ...card }));
+}

--- a/rules/src/index.ts
+++ b/rules/src/index.ts
@@ -1,5 +1,6 @@
 import { createStandardDeck } from './deck';
-import { Card, GameState, HitPointTrack, PlayerHands } from './types';
+import { Card, GameState } from './types';
+import { createGameState } from './game_state';
 
 export * from './types';
 export * from './deck';
@@ -8,39 +9,18 @@ export * from './turn_manager';
 export * from './combos_pegging';
 export * from './score_resolution';
 export * from './damage';
-
-export const DEFAULT_HP = 61;
+export * from './constants';
+export * from './game_state';
 
 export const STANDARD_DECK: ReadonlyArray<Card> = Object.freeze(
   createStandardDeck()
 );
 
 export function createInitialState(seed = Date.now()): GameState {
-  return {
-    seed,
-    round: 0,
-    dealer: 'p1',
-    count: 0,
-    pile: [],
-    turn: 'p1',
-    hands: emptyHands(),
-    cribOwner: 'p1',
-    crib: [],
-    starter: null,
-    hp: defaultHpTrack(),
-    shield: { p1: 0, p2: 0 },
-    phase: 'deal'
-  };
-}
-
-function emptyHands(): PlayerHands {
-  return { p1: [], p2: [] };
-}
-
-function defaultHpTrack(): HitPointTrack {
-  return { p1: DEFAULT_HP, p2: DEFAULT_HP };
+  return createGameState({ seed });
 }
 
 export function getCardValue(card: Card): number {
   return card.value;
 }
+

--- a/rules/src/turn_manager.ts
+++ b/rules/src/turn_manager.ts
@@ -73,9 +73,9 @@ export class PeggingTurnManager {
     if (this.passed[opponent]) {
       const awardedTo = this.lastPlayerToPlay ?? opponent;
       this.resetVolley(awardedTo);
-      return { awardedTo };
+      return { awardedTo, reset: true };
     }
-    return {};
+    return { reset: false };
   }
 
   resetAfterThirtyOne(): void {

--- a/rules/src/types.ts
+++ b/rules/src/types.ts
@@ -25,19 +25,29 @@ export interface HitPointTrack {
   p2: number;
 }
 
+export interface PeggingTracker {
+  passed: Record<PlayerId, boolean>;
+  lastPlayedBy: PlayerId | null;
+}
+
 export interface GameState {
   seed: number;
   round: number;
   dealer: PlayerId;
   count: number;
-  pile: Card[];
+  pile: PeggingPileEntry[];
   turn: PlayerId;
   hands: PlayerHands;
   cribOwner: PlayerId;
   crib: Card[];
   starter: Card | null;
+  deck: Card[];
   hp: HitPointTrack;
   shield: HitPointTrack;
+  damageLog: DamageEvent[];
+  comboLog: ComboLogEntry[];
+  initiative: PlayerId | null;
+  pegging: PeggingTracker;
   phase: GamePhase;
 }
 
@@ -59,6 +69,16 @@ export interface ComboEvent {
   kind: ComboKind;
   damage: number;
   length?: number;
+}
+
+export interface ComboLogEntry {
+  player: PlayerId;
+  combos: ComboEvent[];
+  count: number;
+  pile: PeggingPileEntry[];
+  round: number;
+  phase: GamePhase;
+  timestamp: number;
 }
 
 export type DamageSource = 'pegging' | 'resolution' | 'ability' | 'status';
@@ -99,4 +119,21 @@ export interface PeggingPileEntry {
 
 export interface GoResolution {
   awardedTo?: PlayerId;
+  damageEvent?: DamageEvent;
+  reset: boolean;
+}
+
+export interface PlayCardOutcome {
+  player: PlayerId;
+  card: Card;
+  count: number;
+  combos: ComboEvent[];
+  damageEvent?: DamageEvent;
+  reset: boolean;
+}
+
+export interface ResolutionSummary {
+  handResults: Record<PlayerId, ResolutionResult>;
+  cribResult: ResolutionResult | null;
+  damageEvents: DamageEvent[];
 }

--- a/rules/tests/game_state.test.ts
+++ b/rules/tests/game_state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Card,
+  createGameState,
+  createInitialState,
+  cutStarter,
+  declareGo,
+  discardToCrib,
+  playCard,
+  resolveRound
+} from '../src';
+import { makeCard } from './helpers';
+
+describe('game state lifecycle', () => {
+  it('creates an initial state with shuffled deck, hands, and hp totals', () => {
+    const seed = 1234;
+    const state = createGameState({ seed, dealer: 'p2' });
+
+    expect(state.seed).toBe(seed);
+    expect(state.round).toBe(1);
+    expect(state.dealer).toBe('p2');
+    expect(state.phase).toBe('discard');
+    expect(state.hands.p1).toHaveLength(6);
+    expect(state.hands.p2).toHaveLength(6);
+    expect(state.deck.length).toBe(52 - 12);
+    expect(state.hp.p1).toBe(61);
+    expect(state.hp.p2).toBe(61);
+    expect(state.shield.p1).toBe(0);
+    expect(state.shield.p2).toBe(0);
+    expect(state.cribOwner).toBe('p2');
+    expect(state.turn).toBe('p1');
+  });
+
+  it('transitions through discard and cut phases before pegging', () => {
+    const deck = buildOrderedDeck();
+    const state = createGameState({ deck, dealer: 'p1' });
+
+    discardToCrib(state, 'p1', [state.hands.p1[0].id, state.hands.p1[1].id]);
+    discardToCrib(state, 'p2', [state.hands.p2[0].id, state.hands.p2[1].id]);
+
+    expect(state.phase).toBe('cut');
+    const starter = cutStarter(state);
+    expect(starter).toEqual(state.starter);
+    expect(state.phase).toBe('pegging');
+    expect(state.deck.length).toBe(deck.length - 12 - 1);
+  });
+
+  it('applies pegging combos, damage, and go bonuses', () => {
+    const state = createInitialState();
+    state.phase = 'pegging';
+    state.turn = 'p1';
+    state.count = 10;
+    state.pile = [{ card: makeCard(10, 'clubs'), player: 'p2' }];
+    state.hands.p1 = [makeCard(5, 'hearts')];
+    state.hands.p2 = [];
+
+    const result = playCard(state, 'p1', state.hands.p1[0].id);
+    expect(result.combos.map((combo) => combo.kind)).toContain('fifteen');
+    expect(result.damageEvent?.amount).toBe(3);
+    expect(state.hp.p2).toBe(58);
+    expect(state.comboLog).toHaveLength(1);
+    expect(state.turn).toBe('p2');
+
+    state.turn = 'p2';
+    state.hands.p2 = [];
+    state.pegging.lastPlayedBy = 'p1';
+    const goResult = declareGo(state, 'p2');
+    expect(goResult.reset).toBe(false);
+
+    state.turn = 'p1';
+    state.hands.p1 = [];
+    const awarded = declareGo(state, 'p1');
+    expect(awarded.reset).toBe(true);
+    expect(awarded.awardedTo).toBe('p1');
+    expect(awarded.damageEvent?.amount).toBe(1);
+    expect(state.hp.p2).toBe(57);
+    expect(state.phase).toBe('resolution');
+  });
+
+  it('resolves hands, crib, dealer swap, and initiative from nobs', () => {
+    const state = createGameState({ deck: buildOrderedDeck(), dealer: 'p1' });
+    state.phase = 'resolution';
+    state.starter = makeCard(7, 'clubs');
+    state.hands.p1 = [makeCard(5, 'hearts'), makeCard(10, 'hearts'), makeCard(6, 'hearts'), makeCard(7, 'hearts')];
+    state.hands.p2 = [makeCard(5, 'diamonds'), makeCard(5, 'spades'), makeCard(9, 'hearts'), makeCard(11, 'clubs')];
+    state.crib = [makeCard(2, 'clubs'), makeCard(3, 'diamonds'), makeCard(4, 'spades'), makeCard(6, 'clubs')];
+    state.cribOwner = 'p1';
+
+    const summary = resolveRound(state);
+    expect(summary.handResults.p1.damage).toBeGreaterThan(0);
+    expect(summary.handResults.p1.shield).toBe(4);
+    expect(summary.handResults.p2.damage).toBe(6);
+    expect(summary.cribResult?.damage).toBe(7);
+    expect(state.shield.p1).toBe(4);
+    expect(state.hp.p2).toBe(44);
+    expect(state.hp.p1).toBe(55);
+    expect(state.round).toBe(2);
+    expect(state.dealer).toBe('p2');
+    expect(state.phase).toBe('discard');
+    expect(state.turn).toBe('p2');
+    expect(state.initiative).toBeNull();
+  });
+});
+
+function buildOrderedDeck(): Card[] {
+  const suits: Card['suit'][] = ['hearts', 'diamonds', 'clubs', 'spades'];
+  const deck: Card[] = [];
+  let id = 0;
+  for (const suit of suits) {
+    for (let rank = 1; rank <= 13; rank += 1) {
+      deck.push({
+        id: `${suit}-${rank}-ordered-${id++}`,
+        rank,
+        suit,
+        value: Math.min(rank, 10)
+      });
+    }
+  }
+  return deck;
+}


### PR DESCRIPTION
## Summary
- add constants and expand the shared GameState to track decks, logs, initiative, and pegging status
- implement lifecycle helpers for discard, cut, pegging, go handling, and round resolution using combo scoring
- cover the round flow with new vitest cases exercising damage, shields, initiative, and dealer swapping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf522f92e8832a98335d5893b7eb12